### PR TITLE
Fix token for None after fromimport in PythonLexer

### DIFF
--- a/pygments/lexers/python.py
+++ b/pygments/lexers/python.py
@@ -341,7 +341,7 @@ class PythonLexer(RegexLexer):
             (r'\.', Name.Namespace),
             # if None occurs here, it's "raise x from None", since None can
             # never be a module name
-            (r'None\b', Name.Builtin.Pseudo, '#pop'),
+            (r'None\b', Keyword.Constant, '#pop'),
             (uni_name, Name.Namespace),
             default('#pop'),
         ],


### PR DESCRIPTION
Seems like this behavior remained from Python2Lexer, where it was indeed `Name.Builtin.Pseudo`, but in Python3Lexer it should yield `Keyword.Constant`.